### PR TITLE
import --matchRev option from wdl repo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,8 @@ Options:
   -r                    Search for .pgn(.gz) files recursively in subdirectories
   --allowDuplicates     Allow duplicate directories for test pgns
   --concurrency <N>     Number of concurrent threads to use (default: maximum)
-  --matchEngine <regex> Filter data based on engine name
+  --matchRev <regex>    Filter data based on revision SHA in metadata
+  --matchEngine <regex> Filter data based on engine name in pgns, defaults to matchRev if given
   --matchBook <regex>   Filter data based on book name
   --matchBookInvert     Invert the filter
   -o <path>             Path to output epd file (default: matesieve.epd)


### PR DESCRIPTION
```
> ./matesieve --matchRev ".*9fb58328e363d84e3cf720b018e639b139ba95c2" -r
Looking (recursively) for pgn files in ./pgns
Found 727 .pgn(.gz) files in total.
Filtering pgn files matching revision SHA .*9fb58328e363d84e3cf720b018e639b139ba95c2
Found 12 .pgn(.gz) files, creating 12 chunks for processing.
Processed 12 files
Saved 170239 unique mates from 911417 games to matesieve.epd.
Total time for processing: 16.126 s
```